### PR TITLE
Cleanup for 1.0.0 release

### DIFF
--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -8,26 +8,13 @@
 #
 # ==============================================================================
 #
-# The testing matrix considers ruby/puppet versions supported by SIMP and PE:
-# ------------------------------------------------------------------------------
-# Release       Puppet   Ruby    EOL
-# PE 2019.8     6.22     2.5     2022-12 (LTS)
-# PE 2021.Y     7.x      2.7     Quarterly updates
-#
-# https://puppet.com/docs/pe/latest/component_versions_in_recent_pe_releases.html
-# https://puppet.com/misc/puppet-enterprise-lifecycle
-# ==============================================================================
-#
 # https://docs.github.com/en/actions/reference/events-that-trigger-workflows
 #
-
+---
 name: PR Tests
-on:
+'on':
   pull_request:
     types: [opened, reopened, synchronize]
-
-env:
-  PUPPET_VERSION: '~> 7'
 
 jobs:
   puppet-syntax:
@@ -35,10 +22,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - name: "Install Ruby 2.7"
+      - name: "Install Ruby 3.2"
         uses: ruby/setup-ruby@v1  # ruby/setup-ruby@ec106b438a1ff6ff109590de34ddc62c540232e0
         with:
-          ruby-version: 2.7.8
+          ruby-version: 3.2.11
           bundler-cache: true
       - run: "bundle exec rake syntax"
 
@@ -47,10 +34,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - name: "Install Ruby 2.7"
+      - name: "Install Ruby 3.2"
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7.8
+          ruby-version: 3.2.11
           bundler-cache: true
       - run: "bundle exec rake lint"
       - run: "bundle exec rake metadata_lint"
@@ -61,10 +48,10 @@ jobs:
     continue-on-error: true
     steps:
       - uses: actions/checkout@v7
-      - name: "Install Ruby 2.7"
+      - name: "Install Ruby 3.4"
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7.8
+          ruby-version: 3.4.9
           bundler-cache: true
       - run: |
           bundle show
@@ -75,10 +62,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - name: 'Install Ruby 2.7'
+      - name: 'Install Ruby 3.4'
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7.8
+          ruby-version: 3.4.9
           bundler-cache: true
       - run: bundle exec rake check:dot_underscore
       - run: bundle exec rake check:test_file
@@ -88,10 +75,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - name: 'Install Ruby 2.7'
+      - name: 'Install Ruby 3.4'
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7.8
+          ruby-version: 3.4.9
           bundler-cache: true
       - name: 'Tags and changelogs'
         run: |
@@ -108,10 +95,6 @@ jobs:
     strategy:
       matrix:
         puppet:
-          - label: 'Puppet 7.x [SIMP 6.6/PE 2021.7]'
-            puppet_version: '~> 7.0'
-            ruby_version: '2.7'
-            experimental: false
           - label: 'Puppet 8.x'
             puppet_version: '~> 8.0'
             ruby_version: '3.2'
@@ -127,15 +110,6 @@ jobs:
           ruby-version: ${{matrix.puppet.ruby_version}}
           bundler-cache: true
       - run: 'command -v rpm || if command -v apt-get; then sudo apt-get update; sudo apt-get install -y rpm; fi ||:'
-      - run: 'bundle exec rake spec'
+      - run: 'bundle exec rake parallel_spec'
         continue-on-error: ${{matrix.puppet.experimental}}
 
-#  dump_contexts:
-#    name: 'Examine Context contents'
-#    runs-on: ubuntu-latest
-#    steps:
-#      - name: Dump contexts
-#        env:
-#          GITHUB_CONTEXT: ${{ toJson(github) }}
-#        run: echo "$GITHUB_CONTEXT"
-#

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+* Mon Jun 08 2026 Steven Pritchard <steven.pritchard@gmail.com> - 1.0.0
+- Point `issues_url` at GitHub Issues
+- Drop end-of-life EL7 support; add EL10 across all distros
+- Switch `requirements` from `puppet` to `openvox` (>= 8 < 9)
+- Allow `simp-simplib` 5.x
+
 * Mon Oct 23 2023 Steven Pritchard <steve@sicura.us> - 0.7.0
 - [puppetsync] Add EL9 support
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,12 +1,12 @@
 {
   "name": "simp-tuned",
-  "version": "0.7.0",
+  "version": "1.0.0",
   "author": "SIMP Team",
   "summary": "A SIMP Puppet module for managing tuned/ktune",
   "license": "Apache-2.0",
   "source": "https://github.com/simp/pupmod-simp-tuned",
   "project_page": "https://github.com/simp/pupmod-simp-tuned",
-  "issues_url": "https://simp-project.atlassian.net",
+  "issues_url": "https://github.com/simp/pupmod-simp-tuned/issues",
   "tags": [
     "simp",
     "ktune"
@@ -14,7 +14,7 @@
   "dependencies": [
     {
       "name": "simp/simplib",
-      "version_requirement": ">= 4.9.0 < 5.0.0"
+      "version_requirement": ">= 4.9.0 < 6.0.0"
     },
     {
       "name": "puppetlabs/stdlib",
@@ -25,46 +25,47 @@
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "7",
-        "8",
-        "9"
+        "9",
+        "10"
       ]
     },
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "7",
         "8",
-        "9"
+        "9",
+        "10"
       ]
     },
     {
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
-        "7",
         "8",
-        "9"
+        "9",
+        "10"
       ]
     },
     {
       "operatingsystem": "Rocky",
       "operatingsystemrelease": [
         "8",
-        "9"
+        "9",
+        "10"
       ]
     },
     {
       "operatingsystem": "AlmaLinux",
       "operatingsystemrelease": [
         "8",
-        "9"
+        "9",
+        "10"
       ]
     }
   ],
   "requirements": [
     {
-      "name": "puppet",
-      "version_requirement": ">= 7.0.0 < 9.0.0"
+      "name": "openvox",
+      "version_requirement": ">= 8.0.0 < 9.0.0"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Cleanup for the 1.0.0 release. No API/behavior changes; version bumped to 1.0.0.

- Point `issues_url` at GitHub Issues instead of the retired Atlassian instance.
- Drop end-of-life EL7 support; add EL10 across all distros (Alma/Rocky/RedHat/OracleLinux 8/9/10 plus CentOS 9/10).
- Switch `requirements` from `puppet` to `openvox` (>= 8 < 9). The Gemfile already loads both `openvox` and `puppet` for tests.
- Allow `simp-simplib` 5.x as a dependency.
- Modernize the GitHub Actions workflow:
  - Drop Puppet 7 / Ruby 2.7 from the test matrix.
  - Use Ruby 3.2.11 with OpenVox 8 for spec tests; 3.4.9 elsewhere.
  - Run spec tests in parallel.
  - No acceptance job: this module has no `spec/acceptance/` suites.

## Test plan
- [x] `bundle exec rake metadata_lint` (ruby:3.2 container)
- [x] `bundle exec rake spec` (98 examples, 0 failures)